### PR TITLE
Refreshing get endpoint whenever new version is built

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,6 @@ jobs:
         asset_path: pmm-transferer
         asset_name: pmm-transferer
         asset_content_type: application/x-executable
+
+    - name: Refresh percona/get endpoint
+      run: curl https://percona.com/get/make.php


### PR DESCRIPTION
Modified the release workflow to curl the refresh endpoint for percona/get