### PR TITLE
SE-90 - pmm-dump requires >=glibc 2.32

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,13 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: ^1.20.3
       
     - name: Build
       run: make build
+      env:
+        CGO_ENABLED: 0
+
 
     - name: Test
       run: ./pmm-dump version


### PR DESCRIPTION
Setting CGO_ENABLED=0 to mitigate it (workaround).