### PR TITLE
SE-95: don't create empty QAN chunks

### DIFF
--- a/cmd/pmm-dump/main.go
+++ b/cmd/pmm-dump/main.go
@@ -68,7 +68,7 @@ func main() {
 
 		chunkTimeRange = exportCmd.Flag("chunk-time-range", "Time range to be fit into a single chunk (core metrics). "+
 			"5 minutes by default, example '45s', '5m', '1h'").Default("5m").Duration()
-		chunkRows = exportCmd.Flag("chunk-rows", "Amount of rows to fit into a single chunk (qan metrics)").Default("1000").Int()
+		chunkRows = exportCmd.Flag("chunk-rows", "Amount of rows to fit into a single chunk (qan metrics)").Default("100000").Int()
 
 		ignoreLoad = exportCmd.Flag("ignore-load", "Disable checking for load threshold values").Bool()
 		maxLoad    = exportCmd.Flag("max-load", "Max load threshold values. For the CPU value is overall regardless cores count: 0-100%").


### PR DESCRIPTION
https://jira.percona.com/browse/SE-95

This PR fixes a bug when `pmm-dump` creates a lot of empty QAN chunks on a PMM deployment with large `pmm.metrics` table. In `pmm-dump` before export, we calculate the amount of chunks needed to be created. `(*clickhouse.Source) Count()` method is used for it. This method ignored the `--start-ts` and `--end-ts` options, which produced a bigger amount of chunks than we need.

Also, this PR increases the default value for `--chunk-rows` option from `1000` to `100000`.
