### PR TITLE
SE-101: improve log msg when `--dump-qan` or `--dump-vm` are not specified

### DIFF
--- a/pkg/transferer/import.go
+++ b/pkg/transferer/import.go
@@ -161,7 +161,14 @@ func (t Transferer) writeChunksToSource(ctx context.Context, chunkC <-chan *dump
 
 			s, ok := t.sourceByType(c.Source)
 			if !ok {
-				log.Warn().Msgf("Found dump data for %v, but it's not specified - skipped", c.Source)
+				switch c.Source {
+				case dump.ClickHouse:
+					log.Warn().Msg("Found dump data for QAN, but `--dump-qan` option is not specified - skipped")
+				case dump.VictoriaMetrics:
+					log.Warn().Msg("Found dump data for VictoriaMetrics, but `--dump-vm` option is not specified - skipped")
+				default:
+					log.Warn().Msgf("Found dump data for %v, but it's not specified - skipped", c.Source)
+				}
 				continue
 			}
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/SE-101

During import without `--dump-qan` option, the `pmm-dump` has these log messages:
```
2024-01-10T12:08:09Z INF Processing chunk 'ch/0.tsv'...
2024-01-10T12:08:09Z WRN Found dump data for ch, but it's not specified - skipped
2024-01-10T12:08:09Z INF Successfully imported!
```

The message `Found dump data for ch, but it's not specified - skipped` indicates that QAN data has been found in the dump, but the option `--dump-qan` was not specified. However, this message can be confusing.

Therefore, this pull request changes the message to ```Found dump data for QAN, but `--dump-qan` option is not specified - skipped```, which is  more appropriate.