### PR TITLE
SE-105: improve filtering with `--instance`

### DIFF
--- a/cmd/pmm-dump/main.go
+++ b/cmd/pmm-dump/main.go
@@ -83,7 +83,7 @@ func main() { //nolint:gocyclo,maintidx
 		tsSelector = exportCmd.Flag("ts-selector", "Time series selector to pass to VM").String()
 		where      = exportCmd.Flag("where", "ClickHouse only. WHERE statement").Short('w').String()
 
-		instances  = exportCmd.Flag("instance", "Service name to filter instances. Use multiple times to filter by multiple instances").Strings()
+		instances  = exportCmd.Flag("instance", "Name to filter instances by service names, node names, or instance names. Use multiple times to filter by multiple names").Strings()
 		dashboards = exportCmd.Flag("dashboard", "Dashboard name to filter. Use multiple times to filter by multiple dashboards").Strings()
 
 		chunkTimeRange = exportCmd.Flag("chunk-time-range", "Time range to be fit into a single chunk (core metrics). "+

--- a/cmd/pmm-dump/main.go
+++ b/cmd/pmm-dump/main.go
@@ -216,7 +216,7 @@ func main() { //nolint:gocyclo,maintidx
 			selectors = append(selectors, *tsSelector)
 		} else if len(selectors) == 0 && len(*instances) > 0 {
 			for _, serviceName := range *instances {
-				selectors = append(selectors, fmt.Sprintf(`{service_name="%s"}`, serviceName))
+				selectors = append(selectors, fmt.Sprintf(`{service_name="%s" or node_name="%s" or instance="%s"}`, serviceName, serviceName, serviceName))
 			}
 		}
 		vmSource, ok := prepareVictoriaMetricsSource(grafanaC, *dumpCore, pmmConfig.VictoriaMetricsURL, selectors, *vmNativeData, *vmContentLimit)

--- a/internal/test/e2e/basic_test.go
+++ b/internal/test/e2e/basic_test.go
@@ -48,10 +48,18 @@ func TestExportImport(t *testing.T) {
 	var b util.Binary
 	testDir := t.TempDir()
 
-	args := []string{"-d", filepath.Join(testDir, "dump.tar.gz"), "--pmm-url", pmm.PMMURL(), "--dump-qan", "--click-house-url", pmm.ClickhouseURL()}
+	pmm.Log("Checking filtering with `--instance` flag")
+	args := []string{"-d", filepath.Join(testDir, "filter-dump.tar.gz"), "--pmm-url", pmm.PMMURL(), "--dump-qan", "--click-house-url", pmm.ClickhouseURL(), "--instance", "pmm-client"}
+	stdout, stderr, err := b.Run(append([]string{"export", "--ignore-load"}, args...)...)
+	if err != nil {
+		t.Fatal("failed to export", err, stdout, stderr)
+	}
+	checkDumpFiltering(t, filepath.Join(testDir, "filter-dump.tar.gz"), "pmm-client")
+
+	args = []string{"-d", filepath.Join(testDir, "dump.tar.gz"), "--pmm-url", pmm.PMMURL(), "--dump-qan", "--click-house-url", pmm.ClickhouseURL()}
 
 	pmm.Log("Exporting data to", filepath.Join(testDir, "dump.tar.gz"))
-	stdout, stderr, err := b.Run(append([]string{"export", "--ignore-load"}, args...)...)
+	stdout, stderr, err = b.Run(append([]string{"export", "--ignore-load"}, args...)...)
 	if err != nil {
 		t.Fatal("failed to export", err, stdout, stderr)
 	}

--- a/internal/test/e2e/dashboard_test.go
+++ b/internal/test/e2e/dashboard_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -27,6 +28,7 @@ import (
 
 	"pmm-dump/internal/test/deployment"
 	"pmm-dump/internal/test/util"
+	"pmm-dump/pkg/dump"
 )
 
 func TestDashboard(t *testing.T) {
@@ -55,7 +57,46 @@ func TestDashboard(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to export", err, stdout, stderr)
 			}
+
+			dashboardDumpPath = filepath.Join(testDir, "dump2.tar.gz")
+			args = []string{"-d", dashboardDumpPath, "--pmm-url", pmm.PMMURL(), "--pmm-user", "admin", "--pmm-pass", "admin", "--dashboard", name, "--instance", "pmm-client"}
+			pmm.Log("Exporting data with `--dashboard` flag and `--instance` to", dashboardDumpPath)
+			stdout, stderr, err = b.Run(append([]string{"export", "--ignore-load"}, args...)...)
+			if err != nil {
+				t.Fatal("failed to export", err, stdout, stderr)
+			}
+			checkDumpFiltering(t, dashboardDumpPath, "pmm-client")
 		})
+	}
+}
+
+func checkDumpFiltering(t *testing.T, dumpPath, instanceFilter string) {
+	t.Helper()
+
+	chunkMap, err := readChunks(dumpPath)
+	if err != nil {
+		t.Fatal("failed to read dump", dumpPath)
+	}
+
+	for filename, data := range chunkMap {
+		dir, _ := path.Split(filename)
+		st := dump.ParseSourceType(dir[:len(dir)-1])
+		switch st {
+		case dump.VictoriaMetrics:
+			chunk, err := vmParseChunk(data)
+			if err != nil {
+				t.Fatal("failed to parse chunk", filename)
+			}
+
+			for _, metric := range chunk {
+				if metric.Metric["service_name"] != instanceFilter && metric.Metric["instance"] != instanceFilter && metric.Metric["node_name"] != instanceFilter {
+					t.Fatal("metric", metric, "wasn't filtered by --instance option", instanceFilter, "in chunk", filename)
+				}
+			}
+		case dump.ClickHouse:
+		default:
+			t.Fatal("unknown source type", st)
+		}
 	}
 }
 

--- a/pkg/grafana/expr/vmquery.go
+++ b/pkg/grafana/expr/vmquery.go
@@ -60,16 +60,21 @@ func (p *VMExprParser) parseQuery(query string) ([]string, error) {
 				filters = append(filters, s)
 			}
 		}
-		if len(p.serviceNames) == 1 {
-			filters = append(filters, fmt.Sprintf("%s=~\"%s\"", "service_name", "^"+p.serviceNames[0]+"$"))
-		} else if len(p.serviceNames) > 1 {
-			filters = append(filters, fmt.Sprintf("%s=~\"%s\"", "service_name", "^("+strings.Join(p.serviceNames, "|")+")$"))
-		}
-		if len(filters) == 0 {
+		if len(filters) == 0 && len(p.serviceNames) == 0 {
 			return
 		}
-		s := fmt.Sprintf("{%s}", strings.Join(filters, ","))
-		selectors = append(selectors, s)
+		for _, v := range []string{"service_name", "instance", "node_name"} {
+			var selectorFilters []string
+			selectorFilters = append(selectorFilters, filters...)
+
+			if len(p.serviceNames) == 1 {
+				selectorFilters = append(selectorFilters, fmt.Sprintf("%s=~\"%s\"", v, "^"+p.serviceNames[0]+"$"))
+			} else if len(p.serviceNames) > 1 {
+				selectorFilters = append(selectorFilters, fmt.Sprintf("%s=~\"%s\"", v, "^("+strings.Join(p.serviceNames, "|")+")$"))
+			}
+			s := fmt.Sprintf("{%s}", strings.Join(selectorFilters, ","))
+			selectors = append(selectors, s)
+		}
 	})
 	return selectors, nil
 }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/SE-105

Previously, the `--instance` flag filtered all metrics by the label `service_name`, ignoring metrics with `instance` or `node_name` labels. 

This PR improves filtering using `--instance` flag by additionally keeping metrics with `instance` and `node_name` labels when used.