### PR TITLE
PMM-13282 Migrate to PMM v3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Docker compose environment variables
 # https://docs.docker.com/compose/environment-variables/env-file/#syntax
 
-PMM_VERSION=2 # pmm-server/pmm-client image version
-PMM_SERVER_IMAGE=percona/pmm-server
-PMM_CLIENT_IMAGE=percona/pmm-client
+PMM_VERSION=3-dev-latest # pmm-server/pmm-client image version
+PMM_SERVER_IMAGE=perconalab/pmm-server
+PMM_CLIENT_IMAGE=perconalab/pmm-client
 MONGO_IMAGE=mongo
 MONGO_TAG=latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
 
       - name: Download Go modules
         run: |
@@ -71,10 +70,8 @@ jobs:
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |
-          env
-          go version
-          go env
-          pwd
+          env | sort
+          go env | sort
           git status
 
   check:
@@ -92,7 +89,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache-dependency-path: "**/go.sum"
 
       - name: Download Go modules
         run: |
@@ -137,10 +133,6 @@ jobs:
       - name: Run debug commands on failure
         if: ${{ failure() }}
         run: |
-          env
-          go version
-          go env
-          pwd
+          env | sort
+          go env | sort
           git status
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,14 @@ jobs:
           go clean -testcache
           PMM_DUMP_MAX_PARALLEL_TESTS=3 make run-tests
 
-#       TODO: Add codecoverage
-#      - name: Upload coverage results
-#        uses: codecov/codecov-action@v3
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          file: crosscover.out
-#          flags: crosscover
-#          fail_ci_if_error: false
+      #   TODO: Add codecoverage
+      # - name: Upload coverage results
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     file: crosscover.out
+      #     flags: crosscover
+      #     fail_ci_if_error: false
 
       - name: Check that there are no source code changes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .vscode
+.DS_Store
 
 main
 /pmm-dump

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ up: init
 	mkdir -p setup/pmm && touch setup/pmm/agent.yaml && chmod 0666 setup/pmm/agent.yaml
 	docker compose up -d
 	sleep 15 # waiting for pmm server to be ready :(
-	docker compose exec pmm-client pmm-agent setup || true
+	docker compose exec pmm-client pmm-agent setup
 	docker compose exec pmm-server sed -i 's#<!-- <listen_host>0.0.0.0</listen_host> -->#<listen_host>0.0.0.0</listen_host>#g' /etc/clickhouse-server/config.xml
 	docker compose exec pmm-server supervisorctl restart clickhouse
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PMM Dump (pmm-import-export-tool)
 
-A tool that allows to transfer metrics and QAN data from one PMM Server instance and import it into another one. It helps Percona Services engineers troubleshoot issues.
+PMM Dump is a tool that allows to transfer metrics and QAN data from one PMM Server instance to another. It helps Percona Services engineers troubleshoot issues.
 
 ## How to build?
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # PMM Dump (pmm-import-export-tool)
 
-A tool that will fetch data from PMM and import it into local instance. Will help Percona Services engineers to resolve issues when the customer cannot provide access to their PMM instance.
+A tool that allows to transfer metrics and QAN data from one PMM Server instance and import it into another one. It helps Percona Services engineers troubleshoot issues.
 
 ## How to build?
 
-You will need to have Go 1.16+ installed.
+You will need to have Go 1.21+ installed.
 
 In the root directory: `make build`
 
@@ -68,12 +68,12 @@ You could filter by instance using service name or id. For example, we have regi
 ```
 > pmm-admin add mongodb --username=pmm_mongodb --password=password mongo mongodb:27017
 MongoDB Service added.
-Service ID  : /service_id/6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11
+Service ID  : 6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11
 Service name: mongo
 ```
 
-So the value of `ts-selector` would be: `{service_name="mongo"}` or `{service_id="/service_id/6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11"}`.
-The same for `where` QAN filter: `service_name='mongo'` or `service_id='/service_id/6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11'`.
+So the value of `ts-selector` would be: `{service_name="mongo"}` or `{service_id="6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11"}`.
+The same for `where` QAN filter: `service_name='mongo'` or `service_id='6d7fbaa0-6b21-4c3f-a4a7-4be1e4f58b11'`.
 Also, you can use `instance` option which filters QAN and core metrics by service name
 
 ```
@@ -132,11 +132,11 @@ Dump file is a `tar` archive compressed via `gzip`. Here is the shape of dump fi
 * `dump.tar.gz/ch/` - contains ClickHouse data chunks split by rows count (in TSV format)
 
 
-## Using Makefile - local dev env
+## Using Makefile for local development environment
 
-There is a Makefile for easier testing locally. It uses docker-compose to set up PMM Server, Client and MongoDB.
+There is a Makefile that contains commands to build and test pmm-dump locally. It uses docker-compose to set up PMM Server, PMM Client and MongoDB.
 
-You will need to have Go 1.16+ and Docker installed.
+You will need to have Go 1.21+ and Docker installed.
 
 | Rule                | Description                  |
 | ------------------- | ---------------------------- |
@@ -152,8 +152,8 @@ You will need to have Go 1.16+ and Docker installed.
 | make run-e2e-tests  | Runs all e2e tests           |
 | make run-unit-tests | Runs all unit tests          |
 
-For more rules, please see `Makefile`
+Read `Makefile` for more.
 
 ## Running End-to-End Tests
 
-For detailed instructions on executing end-to-end tests, please refer to the [Exectuing e2e tests](./internal/test/README.md).
+For detailed instructions on executing end-to-end tests, refer to [Executing e2e tests](./internal/test/README.md).

--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -85,7 +85,7 @@ func getPMMVersion(pmmURL string, c *client.Client) (string, string, error) {
 		DistributionMethod string `json:"distribution_method"`
 	}
 
-	statusCode, body, err := c.Get(pmmURL + "/v1/version")
+	statusCode, body, err := c.Get(pmmURL + "/v1/server/version")
 	if err != nil {
 		return "", "", err
 	}
@@ -108,7 +108,7 @@ func getPMMServices(pmmURL string, c *client.Client) ([]dump.PMMServerService, e
 
 	// Services
 
-	statusCode, body, err := c.Post(pmmURL + "/v1/inventory/Services/List")
+	statusCode, body, err := c.Get(pmmURL + "/v1/inventory/services")
 	if err != nil {
 		return nil, err
 	}
@@ -153,9 +153,7 @@ func getPMMServiceNodeName(pmmURL string, c *client.Client, nodeID string) (stri
 		} `json:"generic"`
 	}
 
-	statusCode, body, err := c.PostJSON(pmmURL+"/v1/inventory/Nodes/Get", struct {
-		NodeID string `json:"node_id"`
-	}{nodeID})
+	statusCode, body, err := c.Get(pmmURL + "/v1/inventory/nodes?node_id=" + nodeID)
 	if err != nil {
 		return "", err
 	}
@@ -176,7 +174,7 @@ func getPMMServiceAgentsIds(pmmURL string, c *client.Client, serviceID string) (
 		AgentID   *string `json:"agent_id"`
 	}
 
-	statusCode, body, err := c.Post(pmmURL + "/v1/inventory/Agents/List")
+	statusCode, body, err := c.Get(pmmURL + "/v1/inventory/agents")
 	if err != nil {
 		return nil, err
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,8 +12,8 @@ services:
         max-size: "10m"
         max-file: "5"
     ports:
-      - "${PMM_HTTP_PORT}:80"
-      - "${PMM_HTTPS_PORT}:443"
+      - "${PMM_HTTP_PORT}:8080"
+      - "${PMM_HTTPS_PORT}:8443"
       - "${CLICKHOUSE_PORT}:9000"
       - "${CLICKHOUSE_PORT_HTTP}:8123"
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - PMM_AGENT_CONFIG_FILE=/etc/pmm-agent.yaml
       - PMM_AGENT_SERVER_USERNAME=admin
       - PMM_AGENT_SERVER_PASSWORD=admin
-      - PMM_AGENT_SERVER_ADDRESS=pmm-server:443
+      - PMM_AGENT_SERVER_ADDRESS=pmm-server:8443
       - PMM_AGENT_SERVER_INSECURE_TLS=true
       - PMM_AGENT_SETUP=false
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,7 @@
-version: '3'
-
 services:
   pmm-server:
     image: ${PMM_SERVER_IMAGE}:${PMM_VERSION}
+    platform: linux/amd64 # temp fix until we have multi-architecture images
     hostname: pmm-server
     container_name: "${PMM_SERVER_NAME}"
     restart: always
@@ -18,8 +17,10 @@ services:
       - "${CLICKHOUSE_PORT_HTTP}:8123"
     volumes:
       - pmm-server-data:/srv
+
   pmm-client:
     image: ${PMM_CLIENT_IMAGE}:${PMM_VERSION}
+    platform: linux/amd64 # temp fix until we have multi-architecture images
     hostname: pmm-client
     container_name: "${PMM_CLIENT_NAME}"
     restart: always
@@ -40,6 +41,7 @@ services:
       - PMM_AGENT_SERVER_ADDRESS=pmm-server:443
       - PMM_AGENT_SERVER_INSECURE_TLS=true
       - PMM_AGENT_SETUP=false
+
   mongodb:
     image: "${MONGO_IMAGE}:${MONGO_TAG}"
     container_name: "${PMM_MONGO_NAME}"

--- a/internal/test/deployment/container.go
+++ b/internal/test/deployment/container.go
@@ -100,7 +100,7 @@ func (pmm *PMM) CreatePMMServer(ctx context.Context, dockerCli *client.Client, n
 
 	tCtx, cancel = context.WithTimeout(ctx, getTimeout)
 	defer cancel()
-	if err := getUntilOk(tCtx, pmm.PMMURL()+"/v1/version"); err != nil && !errors.Is(err, io.EOF) {
+	if err := getUntilOk(tCtx, pmm.PMMURL()+"/v1/server/version"); err != nil && !errors.Is(err, io.EOF) {
 		return errors.Wrap(err, "failed to ping PMM")
 	}
 

--- a/internal/test/deployment/container.go
+++ b/internal/test/deployment/container.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	defaultHTTPPort           = "80"
-	defaultHTTPSPort          = "443"
+	defaultHTTPPort           = "8080"
+	defaultHTTPSPort          = "8443"
 	defaultClickhousePort     = "9000"
 	defaultClickhouseHTTPPort = "8123"
 

--- a/internal/test/deployment/container.go
+++ b/internal/test/deployment/container.go
@@ -168,7 +168,7 @@ func (pmm *PMM) CreatePMMClient(ctx context.Context, dockerCli *client.Client, n
 		"PMM_AGENT_CONFIG_FILE=config/pmm-agent.yaml",
 		"PMM_AGENT_SERVER_USERNAME=admin",
 		"PMM_AGENT_SERVER_PASSWORD=admin",
-		"PMM_AGENT_SERVER_ADDRESS=" + pmm.ServerContainerName() + ":443",
+		"PMM_AGENT_SERVER_ADDRESS=" + pmm.ServerContainerName() + ":8443",
 		"PMM_AGENT_SERVER_INSECURE_TLS=1",
 		"PMM_AGENT_SETUP=1",
 		"PMM_AGENT_SETUP_FORCE=true",

--- a/internal/test/deployment/env.go
+++ b/internal/test/deployment/env.go
@@ -71,13 +71,16 @@ func setDefaultEnv(key string) string {
 	case envVarPMMURL:
 		return defaultPMMURL
 	case envVarPMMServerImage:
-		return "percona/pmm-server"
+		return "perconalab/pmm-server"
 	case envVarPMMClientImage:
-		return "percona/pmm-client"
+		return "perconalab/pmm-client"
 	case envVarMongoImage:
 		return "mongo"
-	case envVarMongoTag, envVarPMMVersion:
+	case envVarMongoTag:
 		return "latest"
+	case envVarPMMVersion:
+		// TODO: update this once PMM v3 goes GA
+		return "3-dev-latest"
 	case envVarUseExistingPMM:
 		return "false"
 	default:

--- a/internal/test/deployment/pmm.go
+++ b/internal/test/deployment/pmm.go
@@ -365,7 +365,7 @@ func (pmm *PMM) Restart(ctx context.Context) error {
 
 	tCtx, cancel := context.WithTimeout(ctx, getTimeout)
 	defer cancel()
-	if err := getUntilOk(tCtx, pmm.PMMURL()+"/v1/version"); err != nil && !errors.Is(err, io.EOF) {
+	if err := getUntilOk(tCtx, pmm.PMMURL()+"/v1/server/version"); err != nil && !errors.Is(err, io.EOF) {
 		return errors.Wrap(err, "failed to ping PMM")
 	}
 	return nil

--- a/internal/test/e2e/errmsg_test.go
+++ b/internal/test/e2e/errmsg_test.go
@@ -79,7 +79,7 @@ func TestErrMsgCheckCompatibilityVersion(t *testing.T) {
 							Value: "some-cookie",
 						})
 						w.WriteHeader(http.StatusOK)
-					case "/v1/version":
+					case "/v1/server/version":
 						switch {
 						case tt.internalError:
 							w.WriteHeader(http.StatusInternalServerError)

--- a/internal/test/e2e/testdata/versions.yaml
+++ b/internal/test/e2e/testdata/versions.yaml
@@ -1,7 +1,3 @@
 # List of versions to be used in `TestPMMCompatibility` test
 versions:
-  - "2.33.0"
-  - "2.34.0"
-  - "2.35.0"
-  - "2.36.0"
-  - "2.37.0"
+  - "3-dev-latest"

--- a/internal/test/e2e/version_test.go
+++ b/internal/test/e2e/version_test.go
@@ -37,7 +37,8 @@ func TestPMMCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(pmmVersions) < 2 {
-		t.Fatal("not enough versions to test provided in ")
+		// TODO: make it fail once we have two versions in v3
+		t.Skip("not enough versions to test provided in versions.yaml")
 	}
 
 	c := deployment.NewController(t)

--- a/internal/test/e2e/version_test.go
+++ b/internal/test/e2e/version_test.go
@@ -37,8 +37,7 @@ func TestPMMCompatibility(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(pmmVersions) < 2 {
-		// TODO: make it fail once we have two versions in v3
-		t.Skip("not enough versions to test provided in versions.yaml")
+		t.Skip("Not enough versions to test provided in versions.yaml. skip")
 	}
 
 	c := deployment.NewController(t)

--- a/pkg/grafana/client/client.go
+++ b/pkg/grafana/client/client.go
@@ -76,7 +76,7 @@ type Client struct {
 	password   string
 }
 
-const AuthCookieName = "grafana_session"
+const AuthCookieName = "pmm_session"
 
 func (c *Client) Do(req *fasthttp.Request) (*fasthttp.Response, error) {
 	c.setAuthHeaders(req)

--- a/setup/test/init-test-configs.sh
+++ b/setup/test/init-test-configs.sh
@@ -24,9 +24,9 @@ mkdir -p "$test_dir"
 
 # Create the .env.test file
 env_vars=(
-    "PMM_VERSION=latest # pmm-server/pmm-client image version"
-    "PMM_SERVER_IMAGE=percona/pmm-server"
-    "PMM_CLIENT_IMAGE=percona/pmm-client"
+    "PMM_VERSION=3-dev-latest # pmm-server/pmm-client image version"
+    "PMM_SERVER_IMAGE=perconalab/pmm-server"
+    "PMM_CLIENT_IMAGE=perconalab/pmm-client"
     "MONGO_IMAGE=mongo"
     "MONGO_TAG=latest"
 	"USE_EXISTING_PMM=false # use existing pmm-server container"

--- a/support-files/README.md
+++ b/support-files/README.md
@@ -13,13 +13,13 @@ The main goal of the script is to aide in handling importing data coming from a 
 
 There are three ways to run the script (all of them require at least one parameter -- the ticket number or container name string).
 
-- This will assume latest PMM v2 server version, and will deploy one container: `pmm-server-CS0012345`
+- This will assume latest PMM v3 server version, and will deploy one container: `pmm-server-CS0012345`
 
 `load-pmm-dump CS0012345`
 
 - This will use the second argument as PMM server Docker version tag (all other possible arguments are ignored).
 
-`load-pmm-dump CS0012345 2.26.0`
+`load-pmm-dump CS0012345 3.0.0`
 
 - This will get the PMM server Docker version tag from the .tar.gz/.tgz file metadata, and it will use it for the container. Additionally, it will try to automatically import the data with `pmm-dump import` (optionally, other files can be added as third and following arguments).
 
@@ -42,7 +42,7 @@ date -d @1657948064
 
 ## Increase 'Data Retention' in the advanced settings if the samples are older than the default 30 days.
 ## For example, to increase to 60 days:
-## docker exec pmm-server-CS0037806 curl -s -u admin:admin --request POST -k --url https://127.0.0.1:443/v1/Settings/Change -H 'Content-Type: application/json' -d '{"data_retention":"5184000s"}'
+## docker exec pmm-server-CS0037806 curl -s -u admin:admin --request PUT -k --url https://127.0.0.1:443/v1/server/settings -H 'Content-Type: application/json' -d '{"data_retention":"5184000s"}'
 
 ## To destroy docker PMM server container:
 docker rm -vf pmm-server-CS0037806

--- a/support-files/load-pmm-dump
+++ b/support-files/load-pmm-dump
@@ -74,7 +74,7 @@ echo "## Using version: $pmm_version"
 
 docker pull percona/pmm-server:${pmm_version}
 
-docker run --detach --publish :443 --name pmm-server-${ticket_number} percona/pmm-server:${pmm_version}
+docker run --detach --publish 443:8443 --name pmm-server-${ticket_number} percona/pmm-server:${pmm_version}
 
 pmm_port_443=`docker ps --format "{{.Ports}} {{.Names}}"|grep ${ticket_number}|cut -d ':' -f2|cut -d '-' -f1`
 
@@ -101,7 +101,7 @@ docker exec pmm-server-${ticket_number} supervisorctl restart nginx
 # Wait for PMM server to restart
 echo -n "## Waiting for PMM sever to restart"
 while true; do
-  pmm_status=`docker exec pmm-server-${ticket_number} curl -s -k -u admin:admin https://127.0.0.1:443/v1/readyz`
+  pmm_status=$(docker exec pmm-server-${ticket_number} curl -s -k -u admin:admin https://127.0.0.1:${pmm_port_443}/v1/server/readyz)
   if [[ ${pmm_status} == "{}" ]]; then
     echo
     echo "## PMM sever started"
@@ -184,7 +184,7 @@ echo "date -d @1657948064"
 echo
 echo "## Increase 'Data Retention' in the advanced settings if the samples are older than the default 30 days."
 echo "## For example, to increase to 60 days:"
-echo "## docker exec pmm-server-${ticket_number} curl -s -u admin:admin --request POST -k --url https://127.0.0.1:443/v1/Settings/Change -H 'Content-Type: application/json' -d '{\"data_retention\":\"5184000s\"}'"
+echo "## docker exec pmm-server-${ticket_number} curl -s -u admin:admin --request PUT -k --url https://127.0.0.1:${pmm_port_443}/v1/server/settings -H 'Content-Type: application/json' -d '{\"data_retention\":\"5184000s\"}'"
 echo
 echo "## To destroy docker PMM server container:"
 echo "docker rm -vf pmm-server-${ticket_number}"
@@ -198,4 +198,3 @@ elif [[ ${pmm_dump_import_err} -eq '1' ]]; then
 else
   exit 0
 fi
-

--- a/support-files/load-pmm-dump
+++ b/support-files/load-pmm-dump
@@ -17,7 +17,7 @@
 [[ -z ${1} ]] && {
   echo "ERROR: Arguments expected."
   echo " 1st argument: Ticket number"
-  echo " 2nd argument (optional): PMM-dump tar.gz file, or version for container using percona/pmm-server"
+  echo " 2nd argument (optional): PMM-dump tar.gz file, or version for container using perconalab/pmm-server"
   exit 1
 }
 
@@ -57,11 +57,6 @@ if [[ -n ${2} ]] && [[ arg_is_pmm_dump_file -eq 1 ]] && which pmm-dump > /dev/nu
   fi
   echo "## Getting PMM version from \`pmm-dump show-meta\` outputs (this can take a while if the dump file is large)..."
   pmm_version=`pmm-dump show-meta --dump-path=${2}|grep "PMM Version"|awk '{print $3}'|cut -d '-' -f1`
-  # Fix for https://jira.percona.com/browse/SE-83
-  if [[ ${pmm_version} == "2.33.0" ]]; then
-    echo "## Detected version 2.33.0. Using 2.32.0 instead, due to SE-83."
-    pmm_version="2.32.0"
-  fi
 elif [[ -n ${2} ]] && [[ arg_is_pmm_version -eq 1 ]]; then
   # If the second argument was a string like N[.N[.N]], we set that as version number.
   pmm_version=${2}
@@ -72,9 +67,9 @@ fi
 
 echo "## Using version: $pmm_version"
 
-docker pull percona/pmm-server:${pmm_version}
+docker pull perconalab/pmm-server:${pmm_version}
 
-docker run --detach --publish 443:8443 --name pmm-server-${ticket_number} percona/pmm-server:${pmm_version}
+docker run --detach --publish 443:8443 --name pmm-server-${ticket_number} perconalab/pmm-server:${pmm_version}
 
 pmm_port_443=`docker ps --format "{{.Ports}} {{.Names}}"|grep ${ticket_number}|cut -d ':' -f2|cut -d '-' -f1`
 

--- a/support-files/run-tests
+++ b/support-files/run-tests
@@ -4,7 +4,7 @@
 
 set -o errexit
 
-timeout="6000s"
+timeout="15m"
 build_tag="$1"
 
 trap exit 1 SIGINT


### PR DESCRIPTION
[PMM-13282](https://perconadev.atlassian.net/browse/PMM-13282)


[PMM-13282]: https://perconadev.atlassian.net/browse/PMM-13282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Feature build: https://github.com/Percona-Lab/pmm-submodules/pull/3687

A related PR: https://github.com/percona/pmm/pull/3143

TODO:
1. Set up a protected v3 branch and apply all default configurations to it
2. Revert `perconalab/pmm-server` back to `percona/pmm-server` in both code and README once PMM goes GA