### PR TITLE
Ubuntu latest in the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     timeout-minutes: 15
     continue-on-error: false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test
     timeout-minutes: 15
     continue-on-error: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
 
     steps:


### PR DESCRIPTION
Currently, workflow raises an error that Ubuntu 20 is EOL. This PR replaces this version with ubuntu-latest.