### PR TITLE
PMM-13596: surpress authorization error from timezone (#263)

### DIFF
--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -272,12 +272,13 @@ func composeMeta(pmmURL string, c *client.Client, exportServices bool, cli *king
 
 	var pmmTz *string
 	pmmTzRaw, err := getPMMTimezone(pmmURL, c)
-	if err != nil {
+	switch {
+	case err != nil:
 		log.Err(err).Msg("failed to get PMM timezone")
 		pmmTz = nil
-	} else if pmmTzRaw == "" || pmmTzRaw == "browser" {
+	case pmmTzRaw == "", pmmTzRaw == "browser":
 		pmmTz = nil
-	} else {
+	default:
 		pmmTz = &pmmTzRaw
 	}
 

--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -239,7 +239,7 @@ func getPMMServiceAgentsIds(pmmURL string, c *client.Client, serviceID string, v
 	return agentsIDs, nil
 }
 
-// getTimeZone returns empty string result if there is no preferred timezone in pmm-server graphana settings.
+// getTimeZone returns empty string result if there is no preferred timezone in pmm-server Grafana settings.
 func getPMMTimezone(pmmURL string, c *client.Client) (string, error) {
 	type tzResp struct {
 		Timezone string `json:"timezone"`
@@ -269,12 +269,13 @@ func composeMeta(pmmURL string, c *client.Client, exportServices bool, cli *king
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get major PMM version")
 	}
+
+	var pmmTz *string
 	pmmTzRaw, err := getPMMTimezone(pmmURL, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get PMM timezone")
-	}
-	var pmmTz *string
-	if len(pmmTzRaw) == 0 || pmmTzRaw == "browser" {
+		log.Err(err).Msg("failed to get PMM timezone")
+		pmmTz = nil
+	} else if pmmTzRaw == "" || pmmTzRaw == "browser" {
 		pmmTz = nil
 	} else {
 		pmmTz = &pmmTzRaw


### PR DESCRIPTION
This is a cherry-pick of the original [PR](https://github.com/percona/pmm-dump/pull/263) to bring the changes into main as part of [PMM-14215](https://perconadev.atlassian.net/browse/PMM-14215)

[PMM-14215]: https://perconadev.atlassian.net/browse/PMM-14215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ