### PR TITLE
PMM-14215 Allow git tags override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ ADMIN_MONGO_USERNAME?=admin
 ADMIN_MONGO_PASSWORD?=admin
 DUMP_FILENAME=dump.tar.gz
 
-BRANCH:=$(shell git branch --show-current)
-COMMIT:=$(shell git rev-parse --short HEAD)
-VERSION:=$(shell git describe --tags --abbrev=0)
+BRANCH?=$(shell git branch --show-current)
+COMMIT?=$(shell git rev-parse --short HEAD)
+VERSION?=$(shell git describe --tags --abbrev=0)
 
 all: build re mongo-reg mongo-insert export-all re import-all
 

--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -272,12 +272,13 @@ func composeMeta(pmmURL string, c *client.Client, exportServices bool, cli *king
 
 	var pmmTz *string
 	pmmTzRaw, err := getPMMTimezone(pmmURL, c)
-	if err != nil {
+	switch {
+	case err != nil:
 		log.Err(err).Msg("failed to get PMM timezone")
 		pmmTz = nil
-	} else if pmmTzRaw == "" || pmmTzRaw == "browser" {
+	case pmmTzRaw == "", pmmTzRaw == "browser":
 		pmmTz = nil
-	} else {
+	default:
 		pmmTz = &pmmTzRaw
 	}
 

--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -239,7 +239,7 @@ func getPMMServiceAgentsIds(pmmURL string, c *client.Client, serviceID string, v
 	return agentsIDs, nil
 }
 
-// getTimeZone returns empty string result if there is no preferred timezone in pmm-server graphana settings.
+// getTimeZone returns empty string result if there is no preferred timezone in pmm-server Grafana settings.
 func getPMMTimezone(pmmURL string, c *client.Client) (string, error) {
 	type tzResp struct {
 		Timezone string `json:"timezone"`
@@ -269,12 +269,13 @@ func composeMeta(pmmURL string, c *client.Client, exportServices bool, cli *king
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get major PMM version")
 	}
+
+	var pmmTz *string
 	pmmTzRaw, err := getPMMTimezone(pmmURL, c)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get PMM timezone")
-	}
-	var pmmTz *string
-	if len(pmmTzRaw) == 0 || pmmTzRaw == "browser" {
+		log.Err(err).Msg("failed to get PMM timezone")
+		pmmTz = nil
+	} else if pmmTzRaw == "" || pmmTzRaw == "browser" {
 		pmmTz = nil
 	} else {
 		pmmTz = &pmmTzRaw


### PR DESCRIPTION
PMM dump currently relies on git to get the correct flags (commit, version, etc) that should be passed to go build. When building from PMM (which uses RPM spec files), there is no git context, which leads to blank version information after build.

This change makes those values override-able, so that PMM can then also pass in those information at build time, even without git.