### PR TITLE
[SE-111] Change default generated path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ setup/mongo/db/
 
 pmm-dump-*.tar.gz
 dump.tar.gz
+pmm-dump-*.tar.gz.enc
+dump.tar.gz.enc
 
 /test
 

--- a/cmd/pmm-dump/util.go
+++ b/cmd/pmm-dump/util.go
@@ -542,7 +542,7 @@ func getDumpFilepath(customPath string, ts time.Time, encrypted *bool) (string, 
 	if *encrypted {
 		encpath = ".enc"
 	}
-	autoFilename := fmt.Sprintf("pmm-dump.tar.gz-%v"+encpath, ts.Unix())
+	autoFilename := fmt.Sprintf("pmm-dump-%v.tar.gz"+encpath, ts.Unix())
 	if customPath == "" {
 		return autoFilename, nil
 	}


### PR DESCRIPTION
After fix of SE-97, file name generated as pmm-dump.tar.gz-1757589647.enc, should be pmm-dump-1757589647.tar.gz.enc