### PR TITLE
PMM-14944 Bump Go version to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module pmm-dump
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.42.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/percona-platform/template/tools
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/apache/skywalking-eyes v0.8.0


### PR DESCRIPTION
PMM-14944

This pull request updates the Go version used in both the main project and the tools module from 1.25.8 to 1.25.9. This ensures consistency and takes advantage of any improvements or security patches in the newer Go version. No other changes are included.